### PR TITLE
If record has a `dx` duplex tag, split the read id and compare both halves to see if any is in the unblocked hashset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "noodles"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db4b8fed8af2c156dc4622713e296350f4c87b4898f37811e4c7180cc8767e2"
+checksum = "976f894132b4a6a01e3577693f14dc3069c8d802b33b58ba46586ab1e4dd7bba"
 dependencies = [
  "noodles-bam",
  "noodles-csi",
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-bam"
-version = "0.54.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac62e3b127e29e7f8b9996e829c4c568548d1504251099a21e40256fd4a8224"
+checksum = "bc94309d51e454d7095e56c861f1c320c36cba2e0fc81c3ee7ed8459904ef20a"
 dependencies = [
  "bit-vec",
  "bstr",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "rftools"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rftools"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Alex Payne <alexander.payne@nottingham.ac.uk>", "Rory Munro <rory.munro@nottingham.ac.uk>"]
 edition = "2021"
 
@@ -11,6 +11,6 @@ needletail = { version = "0.4.1", features = ["compression"] }
 csv = "1.1"
 fnv = "1.0.7"
 indicatif = "0.17.7"
-noodles = { version = "0.62.0", features = ["bam", "sam", "csi"] }
+noodles = { version = "0.62.1", features = ["bam", "sam", "csi"] }
 noodles-bgzf = { version = "0.26.0", features = ["libdeflate"] }
 flate2 = { version = "1.0.28", features = ["zlib-ng"] }

--- a/src/split_bam.rs
+++ b/src/split_bam.rs
@@ -50,7 +50,7 @@ use flate2::{write::GzEncoder, Compression};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use noodles::{
     bam::{self, Record},
-    sam::alignment::record::QualityScores,
+    sam::{alignment::record::QualityScores, Header},
 };
 use noodles_bgzf as bgzf;
 use std::{
@@ -105,6 +105,41 @@ fn write_fastq_record<W: Write>(
     writer.write_all(qual)?;
     writer.write_all(NEWLINE_SLICE)?;
     Ok(())
+}
+
+fn create_output_file(
+    fh: String,
+    emit_type: &EmitType,
+    compression: &CompressionType,
+    header: Option<&Header>,
+) -> Option<Wrapper> {
+    match emit_type {
+        EmitType::Bam => {
+            let mut bam: bam::io::Writer<bgzf::Writer<File>> =
+                bam::io::Writer::new(File::create(fh).expect("Failed to create file"));
+            bam.write_header(header.unwrap()).unwrap();
+            Some(Wrapper::Bam(bam))
+        }
+        _ => {
+            let out_file = match File::create(&fh) {
+                Ok(file) => BufWriter::new(file),
+                Err(err) => {
+                    eprintln!("Could not create output file: {}\n{}", &fh, err);
+                    std::process::exit(1)
+                }
+            };
+            match compression {
+                CompressionType::Uncompressed => Some(Wrapper::Fastx(out_file)),
+                CompressionType::Gzipped => {
+                    let gz_out = GzEncoder::new(out_file, Compression::default());
+                    Some(Wrapper::GzFastx(gz_out))
+                }
+                _ => {
+                    unimplemented!()
+                }
+            }
+        }
+    }
 }
 
 /// Write a record to a Fasta file
@@ -230,88 +265,20 @@ pub fn split_bam(
     let (mut sequenced_reads_writer, mut unblocked_reads_writer) = match split_type {
         SplitType::All => {
             // What are we emitting
-            match emit_type {
-                EmitType::Bam => {
-                    let mut sbam: bam::io::Writer<bgzf::Writer<File>> =
-                        bam::io::Writer::new(File::create(seq_fn).expect("Failed to create file"));
-                    let mut ubam =
-                        bam::io::Writer::new(File::create(unb_fn).expect("Failed to create file"));
-                    sbam.write_header(&_header).unwrap();
-                    ubam.write_header(&_header).unwrap();
-                    (Some(Wrapper::Bam(sbam)), Some(Wrapper::Bam(ubam)))
-                }
-                _ => {
-                    let mut _sequenced_reads = match File::create(&seq_fn) {
-                        Ok(file) => BufWriter::new(file),
-                        Err(err) => {
-                            eprintln!("Could not create output file: {}\n{}", &seq_fn, err);
-                            std::process::exit(1)
-                        }
-                    };
-                    let unblocked_reads = match File::create(&unb_fn) {
-                        Ok(file) => BufWriter::new(file),
-                        Err(err) => {
-                            eprintln!("Could not create output file: {}\n{}", &unb_fn, err);
-                            std::process::exit(1)
-                        }
-                    };
-                    match compression {
-                        CompressionType::Uncompressed => (
-                            Some(Wrapper::Fastx(_sequenced_reads)),
-                            Some(Wrapper::Fastx(unblocked_reads)),
-                        ),
-                        CompressionType::Gzipped => {
-                            let gz_seq = GzEncoder::new(_sequenced_reads, Compression::default());
-                            let gz_unb: GzEncoder<BufWriter<File>> =
-                                GzEncoder::new(unblocked_reads, Compression::default());
-                            (
-                                Some(Wrapper::GzFastx(gz_seq)),
-                                Some(Wrapper::GzFastx(gz_unb)),
-                            )
-                        }
-                        _ => {
-                            unimplemented!()
-                        }
-                    }
-                }
-            }
+            (
+                create_output_file(seq_fn, &emit_type, &compression, Some(&_header)),
+                create_output_file(unb_fn, &emit_type, &compression, Some(&_header)),
+            )
         }
-        SplitType::SequencedOnly => match emit_type {
-            EmitType::Bam => {
-                let mut sbam: bam::io::Writer<bgzf::Writer<File>> =
-                    bam::io::Writer::new(File::create(seq_fn).expect("Failed to create file"));
-                sbam.write_header(&_header).unwrap();
-                (Some(Wrapper::Bam(sbam)), None)
-            }
-            _ => {
-                let mut _sequenced_reads = match File::create(&seq_fn) {
-                    Ok(file) => BufWriter::new(file),
-                    Err(err) => {
-                        eprintln!("Could not create output file: {}\n{}", &seq_fn, err);
-                        std::process::exit(1)
-                    }
-                };
-                (Some(Wrapper::Fastx(_sequenced_reads)), None)
-            }
-        },
-        SplitType::UnblockedOnly => match emit_type {
-            EmitType::Bam => {
-                let mut ubam: bam::io::Writer<bgzf::Writer<File>> =
-                    bam::io::Writer::new(File::create(unb_fn).expect("Failed to create file"));
-                ubam.write_header(&_header).unwrap();
-                (None, Some(Wrapper::Bam(ubam)))
-            }
-            _ => {
-                let unblocked_reads = match File::create(&unb_fn) {
-                    Ok(file) => BufWriter::new(file),
-                    Err(err) => {
-                        eprintln!("Could not create output file: {}\n{}", &seq_fn, err);
-                        std::process::exit(1)
-                    }
-                };
-                (None, Some(Wrapper::Fastx(unblocked_reads)))
-            }
-        },
+        SplitType::SequencedOnly => (
+            create_output_file(seq_fn, &emit_type, &compression, Some(&_header)),
+            None,
+        ),
+
+        SplitType::UnblockedOnly => (
+            None,
+            create_output_file(unb_fn, &emit_type, &compression, Some(&_header)),
+        ),
     };
     let mut record = noodles::bam::Record::default();
     let write_unblock = split_type != SplitType::SequencedOnly;


### PR DESCRIPTION
Splits duplex read_id and demultiplexes into sequenced or unblocked according to the parent read id status.

Determines if a read is duplex by looking for the presence of the `dx` tag.